### PR TITLE
removed share

### DIFF
--- a/src/FormatServiceProvider.php
+++ b/src/FormatServiceProvider.php
@@ -14,7 +14,7 @@ class FormatServiceProvider extends ServiceProvider
 
     public function register()
     {
-        $this->app['format'] = $this->app->share(function ($app) {
+        $this->app['format'] = $this->app->singleton(function ($app) {
     
             return new Format();
         });


### PR DESCRIPTION
The share method has been removed from the container. This was a legacy method that has not been documented in several years.
Using "singleton" instead will make this package compatible with > L5.3 too