### PR TITLE
replaced share with singleton

### DIFF
--- a/src/FormatServiceProvider.php
+++ b/src/FormatServiceProvider.php
@@ -14,7 +14,7 @@ class FormatServiceProvider extends ServiceProvider
 
     public function register()
     {
-        $this->app['format'] = $this->app->share(function ($app) {
+        $this->app->singleton('format', function ($app) {
     
             return new Format();
         });


### PR DESCRIPTION
The share method has been removed from the container. This was a legacy method that has not been documented in several years.